### PR TITLE
Log file timestamp will use a human readable format

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -12,15 +12,15 @@
          <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
       </encoder>
    </appender>
- 
+
    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
       <file>/var/log/scalar/cassy.log</file>
       <append>true</append>
       <encoder>
-         <pattern>%-4relative [%thread] %-5level %logger{35} - %msg%n</pattern>
+         <pattern>%d{yyyy-MM-dd} %d{HH:mm:ss.SSS} [%thread] %-5level %logger{35} - %msg%n</pattern>
       </encoder>
    </appender>
- 
+
    <root level="info">
       <appender-ref ref="FILE" />
       <appender-ref ref="STDOUT" />


### PR DESCRIPTION
The log file will output logs will use a human readable format for the timestamp. 

Currently, the log file looks like this :
```
103504 [pool-1-thread-1] INFO  n.s.sshj.transport.TransportImpl - Disconnected - BY_APPLICATION
```
With this PR changes : 
```
2020-03-31 13:45:35.217 [main] INFO  com.scalar.cassy.server.CassyServer - Server started, listening on 20051
```