### PR TITLE
Upgrade picocli to 4.5.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     compile group: 'com.google.inject', name: 'guice', version: '4.2.2'
     compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
     compile group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.560'
-    compile group: 'info.picocli', name: 'picocli', version: '4.0.1'
+    compile group: 'info.picocli', name: 'picocli', version: '4.5.0'
     compile group: 'com.google.api.grpc', name: 'proto-google-common-protos', version: '1.0.0'
     compile group: 'com.google.api.grpc', name: 'googleapis-common-protos', version: '0.0.3'
     compile group: 'io.grpc', name: 'grpc-alts', version: "${grpcVersion}"


### PR DESCRIPTION
This PR updates the `build.gradle` to use a more recent version of picocli.