### PR TITLE
Update asynchronous file download logic 3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ dependencies {
     compile group: 'com.palantir.giraffe', name: 'giraffe-ssh', version: '0.10.0'
     compile group: 'org.xerial', name: 'sqlite-jdbc', version: '3.27.2.1'
     compile group: 'dnsjava', name: 'dnsjava', version: '2.1.9'
-    compile group: 'com.azure', name: 'azure-storage-blob', version: '12.4.0'
+    compile group: 'com.azure', name: 'azure-storage-blob', version: '12.11.0'
     compile group: 'com.azure', name: 'azure-identity', version: '1.0.6'
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.assertj', name: 'assertj-core', version: '3.9.1'

--- a/src/main/java/com/scalar/cassy/transferer/AzureBlobFileDownloader.java
+++ b/src/main/java/com/scalar/cassy/transferer/AzureBlobFileDownloader.java
@@ -20,21 +20,21 @@ import reactor.core.publisher.Mono;
 public class AzureBlobFileDownloader implements FileDownloader {
   private static final Logger logger = LoggerFactory.getLogger(AzureBlobFileDownloader.class);
   private static final int ASYNC_FILE_DOWNLOAD_LIMIT = 3;
-  private BlobContainerAsyncClient blobContainerAsyncClient;
+  private BlobContainerAsyncClient blobContainerClient;
 
   @Inject
   public AzureBlobFileDownloader(BlobContainerAsyncClient blobContainerClient) {
-    this.blobContainerAsyncClient = blobContainerClient;
+    this.blobContainerClient = blobContainerClient;
   }
 
   @Override
   public void download(RestoreConfig config) {
     String key = BackupPath.create(config, config.getKeyspace());
-    logger.info("Downloading " + blobContainerAsyncClient.getBlobContainerName() + "/" + key);
+    logger.info("Downloading " + blobContainerClient.getBlobContainerName() + "/" + key);
 
     List<Mono<BlobProperties>> filesToBeDownloaded = new ArrayList<>();
     Iterable<BlobItem> keyspaceBlobs =
-            blobContainerAsyncClient.listBlobs(new ListBlobsOptions().setPrefix(key + "/")).toIterable();
+            blobContainerClient.listBlobs(new ListBlobsOptions().setPrefix(key + "/")).toIterable();
     for (BlobItem blob : keyspaceBlobs) {
       Path destFile = Paths.get(config.getDataDir(), blob.getName());
 
@@ -45,7 +45,7 @@ public class AzureBlobFileDownloader implements FileDownloader {
       }
 
       filesToBeDownloaded.add(
-          blobContainerAsyncClient
+          blobContainerClient
               .getBlobAsyncClient(blob.getName())
               .downloadToFile(destFile.toString())
               .doOnSuccess(


### PR DESCRIPTION
Azure PSIM Cassy restoration failed after downloading a few files from Storage Blob.

 Caused by: io.netty.util.internal.OutOfDirectMemoryError: failed to allocate 16777216 byte(s) of direct memory (used: 3724541959, max: 3739746304)
                at io.netty.util.internal.PlatformDependent.incrementMemoryCounter(PlatformDependent.java:725)
                at io.netty.util.internal.PlatformDependent.allocateDirectNoCleaner(PlatformDependent.java:680)
                at io.netty.buffer.PoolArena$DirectArena.allocateDirect(PoolArena.java:758)
                at io.netty.buffer.PoolArena$DirectArena.newChunk(PoolArena.java:734)
                at io.netty.buffer.PoolArena.allocateNormal(PoolArena.java:245)
                at io.netty.buffer.PoolArena.allocate(PoolArena.java:227)
                at io.netty.buffer.PoolArena.allocate(PoolArena.java:147)
                at io.netty.buffer.PooledByteBufAllocator.newDirectBuffer(PooledByteBufAllocator.java:342)
                at io.netty.buffer.AbstractByteBufAllocator.directBuffer(AbstractByteBufAllocator.java:187)
                at io.netty.buffer.AbstractByteBufAllocator.directBuffer(AbstractByteBufAllocator.java:178)
                at io.netty.channel.unix.PreferredDirectByteBufAllocator.ioBuffer(PreferredDirectByteBufAllocator.java:53)
                at io.netty.channel.DefaultMaxMessagesRecvByteBufAllocator$MaxMessageHandle.allocate(DefaultMaxMessagesRecvByteBufAllocator.java:114)
                at io.netty.channel.epoll.EpollRecvByteAllocatorHandle.allocate(EpollRecvByteAllocatorHandle.java:75)
                at io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:777)
                at io.netty.channel.epoll.AbstractEpollChannel$AbstractEpollUnsafe$1.run(AbstractEpollChannel.java:394)
                at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:163)
                at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:510)
                at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:388)
                at io.netty.util.concurrent.SingleThreadEventExecutor$6.run(SingleThreadEventExecutor.java:1044)
                at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
                at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
                at java.lang.Thread.run(Thread.java:748)
        Suppressed: java.lang.Exception: #block terminated with an error
                at reactor.core.publisher.BlockingSingleSubscriber.blockingGet(BlockingSingleSubscriber.java:99)
                at reactor.core.publisher.Mono.block(Mono.java:1678)
                at com.scalar.cassy.transferer.AzureBlobFileDownloader.download(AzureBlobFileDownloader.java:58)
                at com.scalar.cassy.service.RestoreService.restore(RestoreService.java:21) 
                at com.scalar.cassy.command.RestoreCommand.lambda$call$0(RestoreCommand.java:69)
                at java.util.Arrays$ArrayList.forEach(Arrays.java:3880)
                at com.scalar.cassy.command.RestoreCommand.call(RestoreCommand.java:66)
                at com.scalar.cassy.command.RestoreCommand.call(RestoreCommand.java:20)
                at picocli.CommandLine.executeUserObject(CommandLine.java:1743)
                at picocli.CommandLine.access$900(CommandLine.java:145)
                at picocli.CommandLine$RunLast.handle(CommandLine.java:2101)
                at picocli.CommandLine$RunLast.handle(CommandLine.java:2068)
                at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:1935)
                at picocli.CommandLine.execute(CommandLine.java:1864)
                at com.scalar.cassy.command.RestoreCommand.main(RestoreCommand.java:36)
Caused by: [CIRCULAR REFERENCE: reactor.netty.ReactorNetty$InternalNettyException: io.netty.util.internal.OutOfDirectMemoryError: failed to allocate 16777216 byte(s) of direct memor
y (used: 3724541959, max: 3739746304)] 